### PR TITLE
Add exclusion for system/'root' accounts from the filtering

### DIFF
--- a/info-dumper.sh
+++ b/info-dumper.sh
@@ -28,6 +28,11 @@ uptime >> /tmp/rpc-dump.txt
 
 # Remove all user names on system
 getent passwd | while IFS=: read -r name password uid gid gecos home shell; do
+  # System accounts shouldn't be redacted, as well as some user accounts
+  if (( $uid < 1000 )); then
+    continue
+  fi
+
   cat /tmp/rpc-dump.txt | awk -v user="$name" '{gsub(user, "[REDACTED]"); print}' | tee /tmp/rpc-dump.txt &>/dev/null
 done
 


### PR DESCRIPTION
Checks if the uid is below 1000 and then skips that iteration of the loop